### PR TITLE
Utilize local storage for Kubelet

### DIFF
--- a/files/20_boot_setup.cfg
+++ b/files/20_boot_setup.cfg
@@ -1,0 +1,2 @@
+bootcmd:
+- [ bash, /etc/eks/local_storage.sh ]

--- a/files/local_storage.sh
+++ b/files/local_storage.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+### setup any local NVME drives as raid0 array
+
+local_drives=($(ls /dev/nvme[1-9]n1 || exit 0))
+sudo mdadm --create /dev/md127 --force --level=stripe --raid-devices=${#local_drives[@]} ${local_drives[@]}
+sudo mkfs.xfs /dev/md127
+echo "/dev/md127 /mnt xfs defaults,noatime 1 1" | sudo tee -a /etc/fstab
+sudo mount /mnt
+
+### setup kubelet to use array
+
+sudo mkdir /mnt/kubelet
+sudo mv /var/lib/kubelet/kubeconfig /tmp/kubeconfig
+echo "/mnt/kubelet /var/lib/kubelet none bind" | sudo tee -a /etc/fstab
+sudo mount /var/lib/kubelet
+sudo mv /tmp/kubeconfig /var/lib/kubelet/kubeconfig

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -21,6 +21,7 @@ sudo yum install -y \
     conntrack \
     curl \
     htop \
+    mdadm \
     nfs-utils \
     nmap \
     ntp \
@@ -132,6 +133,18 @@ sudo mkdir -p /etc/eks
 sudo mv $TEMPLATE_DIR/eni-max-pods.txt /etc/eks/eni-max-pods.txt
 sudo mv $TEMPLATE_DIR/bootstrap.sh /etc/eks/bootstrap.sh
 sudo chmod +x /etc/eks/bootstrap.sh
+
+################################################################################
+### Boot setup #################################################################
+################################################################################
+
+sudo mv $TEMPLATE_DIR/local_storage.sh /etc/eks/local_storage.sh
+sudo chmod +x /etc/eks/local_storage.sh
+sudo mv $TEMPLATE_DIR/20_boot_setup.cfg /etc/cloud/cloud.cfg.d/20_boot_setup.cfg
+
+################################################################################
+### Cleanup ####################################################################
+################################################################################
 
 # Clean up yum caches to reduce the image size
 sudo yum clean all


### PR DESCRIPTION
Certain instance types, like m5d, have ephemeral local NVME storage. We could use this for Kubelet's storage. Any emptyDir volumes mounted by containers then would be persisted to this local storage, which should have much higher I/O than the root EBS volume.