### PR TITLE
Use Ubuntu 18.04 as source AMI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,13 @@ KUBERNETES_VERSION ?= 1.10.3
 
 DATE ?= $(shell date +%Y-%m-%d)
 
-# Defaults to Amazon Linux 2 LTS AMI
-# * use the us-west-2 minimal hvm image
-# https://aws.amazon.com/amazon-linux-2/release-notes/
 SOURCE_AMI_ID ?= $(shell aws ec2 describe-images \
 	--output text \
 	--filters \
-		Name=owner-id,Values=137112412989 \
+		Name=owner-id,Values=099720109477 \
 		Name=virtualization-type,Values=hvm \
 		Name=root-device-type,Values=ebs \
-		Name=name,Values=amzn2-ami-minimal-hvm-* \
+		Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-* \
 		Name=architecture,Values=x86_64 \
 		Name=state,Values=available \
 	--query 'max_by(Images[], &CreationDate).ImageId')
@@ -23,7 +20,7 @@ AWS_DEFAULT_REGION = us-west-2
 all: ami
 
 validate:
-	packer validate eks-worker-al2.json
+	packer validate eks-worker-bionic.json
 
 ami: validate
-	packer build -var source_ami_id=$(SOURCE_AMI_ID) eks-worker-al2.json
+	packer build -var source_ami_id=$(SOURCE_AMI_ID) eks-worker-bionic.json

--- a/eks-worker-bionic.json
+++ b/eks-worker-bionic.json
@@ -31,14 +31,6 @@
       "instance_type": "{{user `instance_type`}}",
       "spot_price": "auto",
       "spot_price_auto_product": "Linux/UNIX (Amazon VPC)",
-      "launch_block_device_mappings": [
-        {
-          "device_name": "/dev/xvda",
-          "volume_type": "gp2",
-          "volume_size": 20,
-          "delete_on_termination": true
-        }
-      ],
       "ssh_username": "ubuntu",
       "ssh_pty": true,
       "encrypt_boot": "{{user `encrypted`}}",

--- a/eks-worker-bionic.json
+++ b/eks-worker-bionic.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "aws_region": "us-west-2",
-    "ami_name": "amazon-eks-node-{{timestamp}}",
+    "ami_name": "bionic-eks-node-{{timestamp}}",
     "binary_bucket_name": "amazon-eks",
     "binary_bucket_region": "us-west-2",
     "binary_bucket_path": "1.10.3/2018-07-26/bin/linux/amd64",
@@ -20,12 +20,12 @@
       "source_ami_filter": {
         "filters": {
           "architecture": "x86_64",
-          "name": "amzn2-ami-minimal-hvm-*",
+          "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*",
           "root-device-type": "ebs",
           "state": "available",
           "virtualization-type": "hvm"
         },
-        "owners": [ "137112412989" ],
+        "owners": [ "099720109477" ],
         "most_recent": true
       },
       "instance_type": "{{user `instance_type`}}",
@@ -39,7 +39,7 @@
           "delete_on_termination": true
         }
       ],
-      "ssh_username": "ec2-user",
+      "ssh_username": "ubuntu",
       "ssh_pty": true,
       "encrypt_boot": "{{user `encrypted`}}",
       "kms_key_id": "{{user `kms_key_id`}}",
@@ -50,7 +50,7 @@
           "created": "{{timestamp}}"
       },
       "ami_name": "{{user `ami_name`}}",
-      "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image"
+      "ami_description": "EKS Kubernetes Worker AMI with Ubuntu 18.04 Bionic image"
     }
   ],
 

--- a/files/iptables-restore.service
+++ b/files/iptables-restore.service
@@ -6,7 +6,7 @@ After=docker.service
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c "/sbin/iptables-restore < /etc/sysconfig/iptables"
+ExecStart=/bin/bash -c "/sbin/iptables-restore < /etc/iptables.rules"
 
 [Install]
 WantedBy=multi-user.target

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -12,25 +12,27 @@ TEMPLATE_DIR=${TEMPLATE_DIR:-/tmp/worker}
 ################################################################################
 
 # Update the OS to begin with to catch up to the latest packages.
-sudo yum update -y
+sudo apt update
+sudo apt-get update
+sudo apt upgrade -y >/dev/null
 
 # Install necessary packages
-sudo yum install -y \
+sudo apt-get install -y --no-install-recommends \
     awscli \
-    aws-cfn-bootstrap \
     conntrack \
     curl \
     htop \
-    nfs-utils \
+    nfs-common \
     nmap \
     ntp \
     socat \
     screen \
     sysstat \
     unzip \
-    wget
+    wget \
+    >/dev/null
 
-sudo systemctl enable ntpd
+sudo systemctl enable ntp
 
 ################################################################################
 ### iptables ###################################################################
@@ -38,7 +40,7 @@ sudo systemctl enable ntpd
 
 # Enable forwarding via iptables
 sudo iptables -P FORWARD ACCEPT
-sudo bash -c "/sbin/iptables-save > /etc/sysconfig/iptables"
+sudo bash -c "/sbin/iptables-save > /etc/iptables.rules"
 
 sudo mv $TEMPLATE_DIR/iptables-restore.service /etc/systemd/system/iptables-restore.service
 
@@ -49,11 +51,9 @@ sudo systemctl enable iptables-restore
 ### Docker #####################################################################
 ################################################################################
 
-sudo yum install -y yum-utils device-mapper-persistent-data lvm2
-sudo amazon-linux-extras enable docker
-sudo yum install -y docker-17.06*
+sudo apt-get install -y --no-install-recommends docker.io=17.12.1-0ubuntu1
 sudo usermod -aG docker $USER
-sudo mkdir /etc/docker
+sudo mkdir -p /etc/docker
 sudo chown root:root /etc/docker
 sudo chmod 700 /etc/docker
 sudo mv $TEMPLATE_DIR/daemon.json /etc/docker/daemon.json
@@ -134,17 +134,18 @@ sudo mv $TEMPLATE_DIR/bootstrap.sh /etc/eks/bootstrap.sh
 sudo chmod +x /etc/eks/bootstrap.sh
 
 # Clean up yum caches to reduce the image size
-sudo yum clean all
+sudo apt-get autoremove -y
 sudo rm -rf \
     $TEMPLATE_DIR  \
-    /var/cache/yum
+    /var/lib/apt/lists \
+    /var/cache/apt/archives
 
 # Clean up files to reduce confusion during debug
 sudo rm -rf \
     /etc/machine-id \
     /etc/ssh/ssh_host* \
     /root/.ssh/authorized_keys \
-    /home/ec2-user/.ssh/authorized_keys \
+    /home/ubuntu/.ssh/authorized_keys \
     /var/log/secure \
     /var/log/wtmp \
     /var/lib/cloud/sem \


### PR DESCRIPTION
Because of issue #51, we may want to use a distro that defaults to ext4 instead of xfs, since the former tends to be more stable.

This PR aims to be as similar as possible to the AL2 EKS AMI, and remains compatible with the [Terraform EKS module](https://github.com/terraform-aws-modules/terraform-aws-eks). One notable difference is that the Docker engine is updated to 17.12 form 17.06, as that's the version included in the Ubuntu 18.04 official repos.