### PR TITLE
Fix DNS resolution.

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -71,6 +71,11 @@ fi
 ZONE=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
 AWS_DEFAULT_REGION=$(echo $ZONE | awk '{print substr($0, 1, length($0)-1)}')
 
+### fix DNS resolution in 18.04
+
+rm /etc/resolv.conf
+ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
+
 ### kubelet kubeconfig
 
 CA_CERTIFICATE_DIRECTORY=/etc/kubernetes/pki


### PR DESCRIPTION
According to [an issue][0] with kubeadm, Ubuntu 18.04 changed its DNS configuration in a way that broke kube-dns. One user suggested removing `/etc/resolv.conf` and symlinking it to systemd's as a solution. This worked when prepended to the user-data, so it should also work as part of the bootstrap script.

[0]: https://github.com/kubernetes/kubeadm/issues/787