### PR TITLE
Port component health checks from GCP K8s image.

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -136,4 +136,8 @@ fi
 
 systemctl daemon-reload
 systemctl enable kubelet
+systemctl enable kubelet-monitor
+systemctl enable kube-container-runtime-monitor
 systemctl start kubelet
+systemctl start kubelet-monitor
+systemctl start kube-container-runtime-monitor

--- a/files/health-monitor.sh
+++ b/files/health-monitor.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is for master and node instance health monitoring, which is
+# packed in kube-manifest tarball. It is executed through a systemd service
+# in cluster/gce/gci/<master/node>.yaml. The env variables come from an env
+# file provided by the systemd service.
+
+set -o nounset
+set -o pipefail
+
+# We simply kill the process when there is a failure. Another systemd service will
+# automatically restart the process.
+function container_runtime_monitoring {
+  local -r max_attempts=5
+  local attempt=1
+  local -r container_runtime_name="${CONTAINER_RUNTIME_NAME:-docker}"
+  local healthcheck_command="docker ps"
+  # Container runtime startup takes time. Make initial attempts before starting
+  # killing the container runtime.
+  until timeout 60 ${healthcheck_command} > /dev/null; do
+    if (( attempt == max_attempts )); then
+      echo "Max attempt ${max_attempts} reached! Proceeding to monitor container runtime healthiness."
+      break
+    fi
+    echo "$attempt initial attempt \"${healthcheck_command}\"! Trying again in $attempt seconds..."
+    sleep "$(( 2 ** attempt++ ))"
+  done
+  while true; do
+    if ! timeout 60 ${healthcheck_command} > /dev/null; then
+      echo "Container runtime ${container_runtime_name} failed!"
+      if [[ "$container_runtime_name" == "docker" ]]; then
+          # Dump stack of docker daemon for investigation.
+          # Log fle name looks like goroutine-stacks-TIMESTAMP and will be saved to
+          # the exec root directory, which is /var/run/docker/ on Ubuntu and COS.
+          pkill -SIGUSR1 dockerd
+      fi
+      systemctl kill --kill-who=main "${container_runtime_name}"
+      # Wait for a while, as we don't want to kill it again before it is really up.
+      sleep 120
+    else
+      sleep "${SLEEP_SECONDS}"
+    fi
+  done
+}
+
+function kubelet_monitoring {
+  echo "Wait for 2 minutes for kubelet to be functional"
+  # TODO(andyzheng0831): replace it with a more reliable method if possible.
+  sleep 120
+  local -r max_seconds=10
+  local output=""
+  while [ 1 ]; do
+    if ! output=$(curl -m "${max_seconds}" -f -s -S http://127.0.0.1:10255/healthz 2>&1); then
+      # Print the response and/or errors.
+      echo $output
+      echo "Kubelet is unhealthy!"
+      systemctl kill kubelet
+      # Wait for a while, as we don't want to kill it again before it is really up.
+      sleep 60
+    else
+      sleep "${SLEEP_SECONDS}"
+    fi
+  done
+}
+
+
+############## Main Function ################
+if [[ "$#" -ne 1 ]]; then
+  echo "Usage: health-monitor.sh <container-runtime/kubelet>"
+  exit 1
+fi
+
+SLEEP_SECONDS=10
+component=$1
+echo "Start kubernetes health monitoring for ${component}"
+if [[ "${component}" == "container-runtime" ]]; then
+  container_runtime_monitoring
+elif [[ "${component}" == "kubelet" ]]; then
+  kubelet_monitoring
+else
+  echo "Health monitoring for component "${component}" is not supported!"
+fi

--- a/files/kube-container-runtime-monitor.service
+++ b/files/kube-container-runtime-monitor.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Kubernetes health monitoring for container runtime
+After=docker.service
+
+[Service]
+Restart=always
+RestartSec=10
+RemainAfterExit=yes
+RemainAfterExit=yes
+ExecStartPre=/bin/chmod 544 /usr/local/bin/health-monitor.sh
+ExecStart=/usr/local/bin/health-monitor.sh container-runtime
+
+[Install]
+WantedBy=multi-user.target

--- a/files/kubelet-monitor.service
+++ b/files/kubelet-monitor.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Kubernetes health monitoring for kubelet
+After=kubelet.service
+
+[Service]
+Restart=always
+RestartSec=10
+RemainAfterExit=yes
+RemainAfterExit=yes
+ExecStartPre=/bin/chmod 544 /usr/local/bin/health-monitor.sh
+ExecStart=/usr/local/bin/health-monitor.sh kubelet
+
+[Install]
+WantedBy=multi-user.target

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -120,6 +120,10 @@ sudo mv $TEMPLATE_DIR/kubelet-kubeconfig /var/lib/kubelet/kubeconfig
 sudo mv $TEMPLATE_DIR/kubelet.service /etc/systemd/system/kubelet.service
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
 
+sudo mv $TEMPLATE_DIR/health-monitor.sh /usr/local/bin/health-monitor.sh
+sudo mv $TEMPLATE_DIR/kubelet-monitor.service /etc/systemd/system/kubelet-monitor.service
+sudo mv $TEMPLATE_DIR/kube-container-runtime-monitor.service /etc/systemd/system/kube-container-runtime-monitor.service
+
 sudo systemctl daemon-reload
 # Disable the kubelet until the proper dropins have been configured
 sudo systemctl disable kubelet


### PR DESCRIPTION
During [presentation on Datadog's usage of K8s][0], they mention that the official GCP image has a health-checking script for both Docker and Kubelet. If either time out, it forcibly kills them. This script and supporting files can be found in the [K8s repository][1]. I've ported them to work with the EKS AMI. For simplicity, I removed support for container runtimes besides Docker, since we're likely to stick with it.

[0]: https://www.youtube.com/watch?v=2dsCwp_j0yQ
[1]: https://github.com/kubernetes/kubernetes/tree/master/cluster/gce/gci