### PR TITLE
Sync with upstream

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -17,8 +17,8 @@ about: Report a bug encountered using the EKS AMI
 **Environment**:
 - AWS Region:
 - Instance Type(s):
-- EKS Platform version (use `aws eks describe-cluster --name eks-mhausler-11-16-2018 --query cluster.platformVersion`):
-- Kubernetes version (use `aws eks describe-cluster --name eks-mhausler-11-16-2018 --query cluster.version`):
+- EKS Platform version (use `aws eks describe-cluster --name <name> --query cluster.platformVersion`):
+- Kubernetes version (use `aws eks describe-cluster --name <name> --query cluster.version`):
 - AMI Version:
 - Kernel (e.g. `uname -a`):
 - Release information (run `cat /tmp/release` on a node):

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -9,8 +9,8 @@ about: Any question relating to the EKS AMI
 **Environment**:
 - AWS Region:
 - Instance Type(s):
-- EKS Platform version (use `aws eks describe-cluster --name eks-mhausler-11-16-2018 --query cluster.platformVersion`):
-- Kubernetes version (use `aws eks describe-cluster --name eks-mhausler-11-16-2018 --query cluster.version`):
+- EKS Platform version (use `aws eks describe-cluster --name <name> --query cluster.platformVersion`):
+- Kubernetes version (use `aws eks describe-cluster --name <name> --query cluster.version`):
 - AMI Version:
 - Kernel (e.g. `uname -a`):
 - Release information (run `cat /tmp/release` on a node):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+### amazon-eks-node-1.11-v20190109 | amazon-eks-node-1.10-v20190109
+
+* 208c114 Make bootstrap script more readable
+* 44d18b7 Addresses #136 - set +e doesn't seem to work. Will return 0 or TEN_RANGE
+* 8a1d7c0 Use chrony for time and make sure it is enabled on startup. (#130)
+* b46b99a Only restart on failures
+* e13d401 Update kubelet.service to be resilient to crashing
+* 2f2401a Reversing order to make easier to read
+* d1c3e0c Added 1.11 build in Makefile
+* 9b8dc41 Fix rendering of the readme file
+* 1797887 Update changelog and readme for 1.10 and 1.11 v20181210 worker nodes
+
+### amazon-eks-node-1.11-v20181210 | amazon-eks-node-1.10-v20181210
+* 87a2aec Added GitHub issue templates
+* 95138f1 Simplified ASG Update parameters
+* 31f7d62 Swap order of `sed` and `kubectl config`
+* 9ad6e2a Add back the allow-privileged kubelet flag
+* 0bf1109 Added serverTLSBootstrap to kubelet config file
+* a5492b2 Added node ASG update policy parameters
+* b7015a6 Remove deprecated flags that use default values
+* d5a6437 Docker config should be owned by root
+* c281f32 Adding mkdir command
+* 90c5eae Adding simple dockerd config file to rotate logs from containers
+* 01090f8 Gracefully handle unknown instance types
+* 68e7a62 Added AMI metadata file
+* c0110a7 Reverted max-pod updates and instance types
+* 90d5209 Correctly select kube-DNS address for secondary CIDR VPC instances
+* f7b7f6c Updated kubelet config file location
+* 8ff10f2 Updated instance types and eni counts
+* 67053cf Modifying kubelet to use config files instead of kubelet flags which are about to deprecate. (#90)
+* 6a20fb1 Add max pods information for g3s.xlarge instances
+* a16af46 kubelet config files should be owned by root
+* f27bc2e Update eni-max-pods.txt
+
 ### amazon-eks-node-v25
 * 45a12de Fix kube-proxy logrotate (#68)
 * 742df5e Change make targets to be .PHONY (#59)

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,25 @@ SOURCE_AMI_ID ?= $(shell aws ec2 describe-images \
 
 AWS_DEFAULT_REGION = us-west-2
 
-.PHONY: all validate ami
+.PHONY: all validate ami 1.11 1.10
 
-all: ami
+all: 1.11
 
 validate:
 	packer validate eks-worker-bionic.json
 
-ami: validate
-	packer build -color=false -var build_tag=$(BUILD_TAG) -var source_ami_id=$(SOURCE_AMI_ID) eks-worker-bionic.json
+1.10: validate
+	packer build \
+		-color=false \
+		-var binary_bucket_path=1.10.11/2018-12-06/bin/linux/amd64 \
+		-var build_tag=$(BUILD_TAG) \
+		-var source_ami_id=$(SOURCE_AMI_ID) \
+		eks-worker-bionic.json
+
+1.11: validate
+	packer build \
+		-color=false \
+		-var binary_bucket_path=1.11.5/2018-12-06/bin/linux/amd64 \
+		-var build_tag=$(BUILD_TAG) \
+		-var source_ami_id=$(SOURCE_AMI_ID) \
+		eks-worker-bionic.json

--- a/eks-worker-bionic.json
+++ b/eks-worker-bionic.json
@@ -5,7 +5,7 @@
     "ami_name": "bionic-eks-node",
     "binary_bucket_name": "amazon-eks",
     "binary_bucket_region": "us-west-2",
-    "binary_bucket_path": "1.11.5/2018-12-06/bin/linux/amd64",
+    "binary_bucket_path": "",
     "creator": "{{env `USER`}}",
     "instance_type": "m4.large",
     "source_ami_id": "",

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -111,9 +111,7 @@ kubectl config \
 
 MAC=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/ -s | head -n 1)
 CIDRS=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks)
-set +e
-TEN_RANGE=$(echo $CIDRS | grep -c '^10\..*')
-set -e
+TEN_RANGE=$(echo $CIDRS | grep -c '^10\..*' || true )
 DNS_CLUSTER_IP=10.100.0.10
 if [[ "$TEN_RANGE" != "0" ]] ; then
     DNS_CLUSTER_IP=172.20.0.10;

--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
 
 Restart=on-failure
+RestartForceExitStatus=SIGPIPE
 RestartSec=5
 KillMode=process
 


### PR DESCRIPTION
Sync our fork with changes from the upstream repository.

Changes incorporated:
* Support building images both for K8s 1.10 and 1.11, with the latter as the default.
* Handle kubelet crashes better.
* Simplify bootstrap script.

Changes left out:
* Switching from NTP to chrony. We may choose to do that later as well.