### PR TITLE
Switch to Docker 18.06.

### DIFF
--- a/eks-worker-bionic.json
+++ b/eks-worker-bionic.json
@@ -6,7 +6,7 @@
     "binary_bucket_name": "amazon-eks",
     "binary_bucket_region": "us-west-2",
     "binary_bucket_path": "1.11.5/2018-12-06/bin/linux/amd64",
-    "docker_version": "17.12.1-0ubuntu1",
+    "docker_version": "18.06.1-0ubuntu1.2~18.04.1",
     "creator": "{{env `USER`}}",
     "instance_type": "m5.large",
     "source_ami_id": "",

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -52,7 +52,7 @@ sudo systemctl enable iptables-restore
 ### Docker #####################################################################
 ################################################################################
 
-DOCKER_VERSION=${DOCKER_VERSION:-"17.12.1-0ubuntu1"}
+DOCKER_VERSION=${DOCKER_VERSION:-"18.06.1-0ubuntu1.2~18.04.1"}
 sudo apt-get install -y --no-install-recommends docker.io=${DOCKER_VERSION}
 sudo usermod -aG docker $USER
 


### PR DESCRIPTION
May hold off on this--K8s 1.11 is only officially validated against Docker 17.03. So technically our AMI already uses an unvalidated version, because 17.06 and 18.06 are the only ones provided officially
in the Ubuntu repos. Once EKS updates to K8s 1.12, though, this branch should be good to merge, as that version is validated with Docker 18.06.