### PR TITLE
Enable live restore for the Docker daemon.

### DIFF
--- a/CHANGELOG_AMS.md
+++ b/CHANGELOG_AMS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2019-01-25
+
+* Enable live restore for Docker daemon.
+
 ### 2018-11-06
 
 * Port kubelet and container-runtime health monitor from GCE K8s image.

--- a/files/docker-daemon.json
+++ b/files/docker-daemon.json
@@ -1,4 +1,5 @@
 {
+  "live-restore": true,
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "10m",


### PR DESCRIPTION
["By default, when the Docker daemon terminates, it shuts down running containers. Starting with Docker Engine 1.12, you can configure the daemon so that containers remain running if the daemon becomes unavailable."][0]

[0]: https://docs.docker.com/config/containers/live-restore/