### PR TITLE
Remove the kubelet-monitor scripts added back in 2018

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -506,8 +506,6 @@ fi
 
 
 systemctl enable kubelet
-systemctl enable kubelet-monitor
-systemctl enable kube-container-runtime-monitor
 systemctl start kubelet
 
 # gpu boost clock


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removes some added items from the bootstrap script that we no longer require.
